### PR TITLE
Pin GitHub actions version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "08:30"
+      timezone: "Asia/Tokyo"
+    target-branch: "master"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "08:30"
+      timezone: "Asia/Tokyo"
+    target-branch: "master"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: 'go.mod'
 
-      - uses: goreleaser/goreleaser-action@v5
+      - uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
+      - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           version: latest
           args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - main: ./cmd/rungcal/
     binary: rungcal


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to pin actions to specific commit hashes instead of using tags. This change is implemented to mitigate supply chain security risks as recommended in the Wiz.io blog post regarding the reviewdog/action-setup vulnerability.

By pinning actions to specific commit hashes, we ensure that the workflow uses a specific, immutable version of the action, preventing potential malicious modifications from affecting our build process. https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup#which-actions-should-security-teams-take-17

In addition to that, this PR adds the following two additional points

- Updated goreleaser 5 to 6 and modified associated configuration file
- Add dependabot configuration file for easy update of gomod / github-actions by Dependabot